### PR TITLE
added list group to navigate in about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -41,12 +41,12 @@
         id="navbarNavDropdown"
       >
         <ul class="navbar-nav d-flex justify-content-around w-100">
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="index.html"
               >Home <span class="sr-only">(current)</span></a
             >
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="about.html"
               >About <span class="sr-only">(current)</span></a
             >
@@ -63,7 +63,7 @@
     <!-- Navbar End -->
 
     <!-- List Group Start -->
-    <div class="row">
+    <div class="row d-flex space-around">
       <div class="col-4">
         <div class="list-group" id="list-tab" role="tablist">
           <a
@@ -73,7 +73,7 @@
             href="#list-home"
             role="tab"
             aria-controls="home"
-            >History Of Jodhpur</a
+            >History of Jodhpur</a
           >
           <a
             class="list-group-item list-group-item-action"

--- a/about.html
+++ b/about.html
@@ -62,6 +62,120 @@
     </nav>
     <!-- Navbar End -->
 
+    <!-- List Group Start -->
+    <div class="row">
+      <div class="col-4">
+        <div class="list-group" id="list-tab" role="tablist">
+          <a
+            class="list-group-item list-group-item-action active"
+            id="list-home-list"
+            data-toggle="list"
+            href="#list-home"
+            role="tab"
+            aria-controls="home"
+            >History Of Jodhpur</a
+          >
+          <a
+            class="list-group-item list-group-item-action"
+            id="list-profile-list"
+            data-toggle="list"
+            href="#list-profile"
+            role="tab"
+            aria-controls="profile"
+            >Learn More</a
+          >
+          <a
+            class="list-group-item list-group-item-action"
+            id="list-messages-list"
+            data-toggle="list"
+            href="#list-messages"
+            role="tab"
+            aria-controls="messages"
+            >News</a
+          >
+        </div>
+      </div>
+      <div class="col-8">
+        <div class="tab-content" id="nav-tabContent">
+          <div
+            class="tab-pane fade show active"
+            id="list-home"
+            role="tabpanel"
+            aria-labelledby="list-history-list"
+          >
+            <h1>History of Jodhpur</h1>
+            <p>
+              Jodhpurs were adapted from traditional clothing of the Indian
+              subcontinent as long trousers, reaching to the ankle, snug from
+              the calf to the ankle, with reinforced fabric protecting the inner
+              calf and knee from rubbing. The thighs and hips were flared, a
+              traditional South Asian style that allowed free movement of the
+              hip and thigh while riding.
+            </p>
+            <p>
+              The jodhpurs were adapted from an ancient style of Indian trouser
+              called the Churidar, which is tight around the calf and loose at
+              the hips. It is still worn at traditional Jodhpuri weddings. This
+              is a special traditional style of clothing in Northern India,
+              especially in what is today the modern state of Rajasthan. Sir
+              Pratap Singh, a younger son of the Maharaja of Jodhpur,
+              popularised in England the style of riding-trousers worn in
+              Jodhpur, a design that he apparently improved and perfected and
+              first had tailored in India around 1890.
+            </p>
+            <p>
+              Singh was an avid polo player. When he visited Queen Victoria in
+              England during her Diamond Jubilee celebrations of 1897, he
+              brought his entire polo team, who caused a sensation among the
+              fashionable circles of the United Kingdom by their riding clothes.
+              In addition, they won many polo matches. Singh's jodhpur style of
+              flared thigh and hip was rapidly taken up by the British
+              polo-playing community, who adapted it to the existing designs of
+              English breeches, which ended snugly at mid-calf, and were worn
+              with tall riding boots.
+            </p>
+          </div>
+          <div
+            class="tab-pane fade"
+            id="list-profile"
+            role="tabpanel"
+            aria-labelledby="list-learn-list"
+          >
+            <h1>Learn More</h1>
+            <p>
+              Cupidatat quis ad sint excepteur laborum in esse qui. Et excepteur
+              consectetur ex nisi eu do cillum ad laborum. Mollit et eu officia
+              dolore sunt Lorem culpa qui commodo velit ex amet id ex. Officia
+              anim incididunt laboris deserunt anim aute dolor incididunt veniam
+              aute dolore do exercitation. Dolor nisi culpa ex ad irure in elit
+              eu dolore. Ad laboris ipsum reprehenderit irure non commodo enim
+              culpa commodo veniam incididunt veniam ad.
+            </p>
+          </div>
+          <div
+            class="tab-pane fade"
+            id="list-messages"
+            role="tabpanel"
+            aria-labelledby="list-news-list"
+          >
+            <h1>News</h1>
+            <p>
+              Ut ut do pariatur aliquip aliqua aliquip exercitation do nostrud
+              commodo reprehenderit aute ipsum voluptate. Irure Lorem et laboris
+              nostrud amet cupidatat cupidatat anim do ut velit mollit consequat
+              enim tempor. Consectetur est minim nostrud nostrud consectetur
+              irure labore voluptate irure. Ipsum id Lorem sit sint voluptate
+              est pariatur eu ad cupidatat et deserunt culpa sit eiusmod
+              deserunt. Consectetur et fugiat anim do eiusmod aliquip nulla
+              laborum elit adipisicing pariatur cillum.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!--list group end-->
+
     <!-- Footer Start -->
     <div class="text-right footer--container">
       <p class="mr-2 footer--content">

--- a/main.css
+++ b/main.css
@@ -27,3 +27,25 @@ body {
     color: violet;
 }
 
+.col-4 {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+    position: relative;
+    width: 100%;
+}
+
+.tab-content h1 {
+    text-align: end;
+    border-bottom: 1px solid gray;
+    display: inline-block;
+    letter-spacing: 2px;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+.col-4 {
+    padding: 50px;
+    margin: 10px;
+    width: 200px;
+    box-sizing: border-box;
+}

--- a/main.css
+++ b/main.css
@@ -27,25 +27,38 @@ body {
     color: violet;
 }
 
-.col-4 {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 100%;
-    position: relative;
-    width: 100%;
-}
+
 
 .tab-content h1 {
-    text-align: end;
+    justify-content: center;
     border-bottom: 1px solid gray;
     display: inline-block;
     letter-spacing: 2px;
     font-family: 'Courier New', Courier, monospace;
 }
 
+.tab-content {
+    justify-content: space-around;
+    padding: 50px;
+    margin-left: 0;
+    /* margin-left: 0; */
+}
+
+.tab-content p {
+    margin-left: auto;
+}
+
 .col-4 {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+    position: relative;
     padding: 50px;
     margin: 10px;
     width: 200px;
     box-sizing: border-box;
+}
+
+.list-group {
+    margin-left: 60px;
 }


### PR DESCRIPTION

## Description
Added navigation in about page using bootstrap 

## Related Issue
#14 

## Motivation and Context
This adds navigation in the about page detailed in issue ticket 14

## How Can This Be Tested?
Hs -o 
navigate to about page 
press tabs on page
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)