### PR TITLE
display number of items in cart in navbar

### DIFF
--- a/main.js
+++ b/main.js
@@ -115,6 +115,7 @@ const addToCart = (e) => {
             cart.push(products[i]);
         }
     }
+    printToDom('cart-nav', `Cart: ${cart.length}`);
 }
 
 const addToWishlist = (e) => {

--- a/products.html
+++ b/products.html
@@ -53,7 +53,7 @@
             <a class="nav-link" href="products.html">Products <span class="sr-only">(current)</span></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">Cart</a>
+            <a class="nav-link" id="cart-nav">Cart</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Description
Displays the number of items in the cart within the navbar whenever a user adds an item to the cart.

## Related Issue
#34 

## Motivation and Context
- Without this change the user is not able to see the number of items in the cart without navigating away from the products page.

## How Can This Be Tested?
```git fetch origin mp-cart-items-navbar```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)