### PR TITLE
add ability to see number of items in wishlist within the nav

### DIFF
--- a/about.html
+++ b/about.html
@@ -55,7 +55,10 @@
             <a class="nav-link" href="products.html">Products</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">Cart</a>
+            <a class="nav-link" id="cart-nav">Cart</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" id="wishlist-nav">Wishlist</a>
           </li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -53,8 +53,11 @@
 						<a class="nav-link" href="products.html">Products</a>
 					</li>
 					<li class="nav-item">
-						<a class="nav-link" href="#">Cart</a>
-					</li>
+						<a class="nav-link" id= "cart-nav">Cart</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="wishlist-nav">Wishlist</a>
+                    </li>
 				</ul>
 			</div>
 		</nav>

--- a/main.js
+++ b/main.js
@@ -125,6 +125,7 @@ const addToWishlist = (e) => {
             wishlist.push(products[i]);
         }
     }
+    printToDom('wishlist-nav', `Wishlist: ${wishlist.length}`);
 }
 
 const buttonEvents = () => {

--- a/products.html
+++ b/products.html
@@ -55,6 +55,9 @@
           <li class="nav-item">
             <a class="nav-link" id="cart-nav">Cart</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" id="wishlist-nav">Wishlist</a>
+          </li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
##Description
- Added wishlist to the nav and added ability to display number of items in the wishlist whenever the Add to Wishlist button is clicked. 

## Related Issue
- #35 

## Motivation and Context
- This change allows the user to see the number of items within their wishlist without navigating away from the products page.

## How Can This Be Tested?
```git fetch origin mp-wishlist-items-nav```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)