### PR TITLE
allow the selected size to be passed to the cart array on add to cart

### DIFF
--- a/main.css
+++ b/main.css
@@ -27,8 +27,6 @@ body {
     color: violet;
 }
 
-
-
 .tab-content h1 {
     justify-content: center;
     border-bottom: 1px solid gray;

--- a/main.js
+++ b/main.js
@@ -83,16 +83,14 @@ const buildCards = () => {
                         <img class="card-img-top" src="${products[i].image}" alt="Card image cap">
                         <div class="card-body">
                             <h5 class="card-title">${products[i].price}</h5>
-                            <div class="dropdown m-2">
-                                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Sizes</button>
-                                    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                                        ${sizeList(products[i])}
-                                    </div>
-                            </div>
+                            <select class="form-control m-2" id="size-list-${i}">
+                                <option selected disabled>Sizes</option>
+                                ${sizeList(products[i])}
+                            </select>
                             <p class="card-text">${products[i].description}</p>
                             <div class="container d-flex">
-                                <a id="add-to-cart-${[i]}"class="btn btn-primary m-1">Add to Cart</a>
-                                <a id="add-to-wishlist-${[i]}"class="btn btn-primary m-1">Add to Wishlist</a>
+                                <a id="add-to-cart-${i}"class="btn btn-primary m-1">Add to Cart</a>
+                                <a id="add-to-wishlist-${i}"class="btn btn-primary m-1">Add to Wishlist</a>
                             </div>
                         </div>
                     </div>`;
@@ -103,7 +101,7 @@ const buildCards = () => {
 const sizeList = (p) => {
     let domString = '';
     for (let i = 0; i < p.sizes.length; i++){
-        domString += `<a class="dropdown-item">${p.sizes[i]}</a>`
+        domString += `<option class="dropdown-item" value="${p.sizes[i]}">${p.sizes[i]}</option>`
     }
     return domString;
 }
@@ -112,6 +110,8 @@ const addToCart = (e) => {
     const target = e.target.id;
     for (let i = 0; i < products.length; i++){
         if (target === `add-to-cart-${[i]}`){
+            let x = document.querySelector(`#size-list-${i}`);
+            products[i].selectedSize = x.options[x.selectedIndex].value;
             cart.push(products[i]);
         }
     }

--- a/main.js
+++ b/main.js
@@ -83,8 +83,8 @@ const buildCards = () => {
                         <img class="card-img-top" src="${products[i].image}" alt="Card image cap">
                         <div class="card-body">
                             <h5 class="card-title">${products[i].price}</h5>
+                            <h5> Sizes: </h5>
                             <select class="form-control m-2" id="size-list-${i}">
-                                <option selected disabled>Sizes</option>
                                 ${sizeList(products[i])}
                             </select>
                             <p class="card-text">${products[i].description}</p>


### PR DESCRIPTION
## Description
- Allow the selected size to be passed to the cart array whenever the add to cart button is clicked.

## Related Issue
#12 

## Motivation and Context
- This change will allow the selected size to be accessed and displayed on the cart page.

## How Can This Be Tested?
```git fetch origin mp-select-size```
(add console.log(cart) to line 115 and check the content of the object that is logged)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)