### PR TITLE
add fixed width to card to make cards responsive

### DIFF
--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ const buildCards = (arr, length, divId) => {
     let domString = '';
     for (let i = 0; i < length; i++){
         if (document.URL.includes('products.html')) {
-        domString += `<div class="card text-center" style="width: 30%; margin: 1%;">
+        domString += `<div class="card text-center" style="width: 331px; margin: 1%;">
                         <h5 class="card-title mt-2">${arr[i].name}</h5>
                         <img class="card-img-top" src="${arr[i].image}" alt="Card image cap">
                         <div class="card-body">


### PR DESCRIPTION
## Description
-Make width of product cards fixed rather than percentage based.

## Related Issue
N/A

## Motivation and Context
- Makes cards responsive and not overlap on any size viewport.

## How Can This Be Tested?
```git fetch origin mp-fixed-width-card```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)