### PR TITLE
allow navbar to collapse when viewport reaches small size

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,7 +37,7 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div
-        class="collapse navbar-collapse m-0 d-block p-2 justify-content-around"
+        class="collapse navbar-collapse m-0 p-2 justify-content-around"
         id="navbarNavDropdown"
       >
         <ul class="navbar-nav d-flex justify-content-around w-100">
@@ -55,10 +55,10 @@
             <a class="nav-link" href="products.html">Products</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" id="cart-nav">Cart</a>
+            <a class="nav-link" id="cart-nav" href="">Cart</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" id="wishlist-nav">Wishlist</a>
+            <a class="nav-link" id="wishlist-nav" href="">Wishlist</a>
           </li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 				<span class="navbar-toggler-icon"></span>
 			</button>
 			<div
-				class="collapse navbar-collapse m-0 d-block p-2 justify-content-around"
+				class="collapse navbar-collapse m-0 p-2 justify-content-around"
 				id="navbarNavDropdown"
 			>
 				<ul class="navbar-nav d-flex justify-content-around w-100">
@@ -53,10 +53,10 @@
 						<a class="nav-link" href="products.html">Products</a>
 					</li>
 					<li class="nav-item">
-						<a class="nav-link" id="cart-nav">Cart</a>
+						<a class="nav-link" id="cart-nav" href="">Cart</a>
 					</li>
 					<li class="nav-item">
-						<a class="nav-link" id="wishlist-nav">Wishlist</a>
+						<a class="nav-link" id="wishlist-nav" href="">Wishlist</a>
 					</li>
 				</ul>
 			</div>

--- a/products.html
+++ b/products.html
@@ -37,7 +37,7 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div
-        class="collapse navbar-collapse m-0 d-block p-2 justify-content-around"
+        class="collapse navbar-collapse m-0 p-2 justify-content-around"
         id="navbarNavDropdown"
       >
         <ul class="navbar-nav d-flex justify-content-around w-100">
@@ -53,10 +53,10 @@
             <a class="nav-link" href="products.html">Products <span class="sr-only">(current)</span></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" id="cart-nav">Cart</a>
+            <a class="nav-link" id="cart-nav" href="">Cart</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" id="wishlist-nav">Wishlist</a>
+            <a class="nav-link" id="wishlist-nav" href="">Wishlist</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Description
- Allows the navbar to collapse when viewport drops below a certain size.

## Related Issue
N/A

## Motivation and Context
- Without this change the navbar does not collapse due to display: block being applied to the navbar.

## How Can This Be Tested?
```git fetch origin mp-navbar-fix```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)